### PR TITLE
remove light weight from font before making bold

### DIFF
--- a/Source/Extensions/NSMutableAttributedString+Helpers.swift
+++ b/Source/Extensions/NSMutableAttributedString+Helpers.swift
@@ -91,7 +91,7 @@ extension NSMutableAttributedString {
     /// Boldens the font while preserving existing symbolic traits.
     func bolden() {
         map(overKey: NSFontAttributeName) { (font: UIFont) -> UIFont in
-            return font.bold
+            return font.withoutLightWeight.bold
         }
     }
     
@@ -99,7 +99,7 @@ extension NSMutableAttributedString {
     /// the font size.
     func bolden(with size: CGFloat) {
         map(overKey: NSFontAttributeName) { (font: UIFont) -> UIFont in
-            return font.withSize(size).bold
+            return font.withoutLightWeight.withSize(size).bold
         }
     }
     

--- a/Source/Style/DownStyle.swift
+++ b/Source/Style/DownStyle.swift
@@ -244,6 +244,17 @@ extension NSParagraphStyle {
 
 public extension UIFont {
     
+    /// A copy of the font without the light weight.
+    public var withoutLightWeight: UIFont {
+        guard fontName.contains("Light") else { return self }
+        guard let name = fontName.split(separator: "-").first else { return self }
+        let fontDesc = UIFontDescriptor(fontAttributes: [UIFontDescriptorNameAttribute: name])
+        // create the font again
+        let font = UIFont(descriptor: fontDesc, size: pointSize)
+        // preserve italic trait
+        return isItalic ? font.italic : font
+    }
+    
     // MARK: - Trait Querying
     
     public var isBold: Bool {

--- a/Tests/NSMutableAttributedStringTests.swift
+++ b/Tests/NSMutableAttributedStringTests.swift
@@ -96,6 +96,20 @@ class NSMutableAttributedStringTests: XCTestCase {
         var range = NSMakeRange(NSNotFound, 0)
         let font = sut.attribute(.font, at: 0, effectiveRange: &range) as? UIFont
         XCTAssertEqual(UIFont.boldSystemFont(ofSize: 24), font)
+    }
+    
+    func testThatItBoldensAndPreservesItalics() {
+        // GIVEN
+        sut = NSMutableAttributedString(string: "example", attributes: [.font: UIFont.italicSystemFont(ofSize: 16)])
+        // WHEN
+        sut.bolden()
+        // THEN
+        var range = NSMakeRange(NSNotFound, 0)
+        let font = sut.attribute(.font, at: 0, effectiveRange: &range) as? UIFont
+        XCTAssertNotNil(font)
+        XCTAssertTrue(font!.isBold)
+        XCTAssertTrue(font!.isItalic)
+        XCTAssertEqual(16, font!.pointSize)
         XCTAssertEqual(NSMakeRange(0, sut.length), range)
     }
     


### PR DESCRIPTION
## Issue
If the base font is system font light, then inserting the bold trait has no effect.

## Solution
Before boldening the font, check if it is light weight, if so, recreate the font with the standard weight and proceed to bolden it.