### PR TITLE
Recognize true bullet points

### DIFF
--- a/Source/AttributeParser/AttributedStringParser.swift
+++ b/Source/AttributeParser/AttributedStringParser.swift
@@ -172,7 +172,20 @@ public class AttributedStringParser {
     private func prepare(input: NSAttributedString) -> NSAttributedString {
         let attrStr = NSMutableAttributedString(attributedString: input)
         
-        // first check that there is a newline after every header, insert
+        // find occurrences of true bullet points
+        if let regex = try? NSRegularExpression(pattern: "^\\s*(•)\\s+", options: .anchorsMatchLines) {
+            let ranges = regex
+                        .matches(in: attrStr.string, options: [], range: NSMakeRange(0, (attrStr.string as NSString).length))
+                        .map { $0.rangeAt(1) }
+            
+            // replace with a dash
+            ranges.forEach {
+                let attrsAtRange = attrStr.attributes(at: $0.location, effectiveRange: nil)
+                attrStr.replaceCharacters(in: $0, with: NSAttributedString(string: "-", attributes: attrsAtRange))
+            }
+        }
+        
+        // next check that there is a newline after every header, insert
         // one if needed
         for header in [Markdown.h1, .h2, .h3] {
             var locationsToInsertNewlines = [Int]()

--- a/Tests/AttributedStringParserTests.swift
+++ b/Tests/AttributedStringParserTests.swift
@@ -484,6 +484,27 @@ class AttributedStringParserTests: XCTestCase {
         XCTAssertEqual(expectation, result)
     }
     
+    // MARK: - Input Preparation (Bullet Points)
+    
+    func testThatItReplacesTrueBulletPointsWithDashes() {
+        // GIVEN
+        let input = combine(
+            text("• One\n", with: .uList),
+            text("•   Two\n", with: .uList),
+            text(" • Three\n", with: .uList)
+        )
+        // WHEN
+        let result = sut.parse(attributedString: input)
+        // THEN
+        let expectation =   """
+                            - One
+                            -   Two
+                             - Three
+
+                            """
+        XCTAssertEqual(expectation, result)
+    }
+    
     // MARK: - Long Input
     
     func testThatItParsesLongInput() {


### PR DESCRIPTION
## Issue
An unordered list which contains true bullet points `•` does not get parsed since the only valid symbols are `- + *` .

## Solution
Before parsing the attributed string, replace any true bullet points with a dash.