### PR TITLE
make list prefix color same as baseFontColor

### DIFF
--- a/Source/Style/DownStyle.swift
+++ b/Source/Style/DownStyle.swift
@@ -83,7 +83,9 @@ import UIKit
     
     var listPrefixAttributes: Attributes {
         let font = UIFont.monospacedDigitSystemFont(ofSize: baseFont.pointSize, weight: UIFontWeightLight)
-        return [NSFontAttributeName: font]
+        return [NSFontAttributeName: font,
+                NSForegroundColorAttributeName: baseFontColor
+        ]
     }
     
     var oListAttributes: Attributes {


### PR DESCRIPTION
## Issue
The list prefix color was not the same as the `baseFontColor`

## Solution
Use the base color when rendering the list prefix.