### PR TITLE
remove restriction that link name is not a url

### DIFF
--- a/Source/AST/AST.swift
+++ b/Source/AST/AST.swift
@@ -375,14 +375,11 @@ extension Inline : Renderable {
                 
                 // first ensure the urlStr is valid
                 if let url = getURL(urlStr), Application.shared.canOpenURL(url) {
-                    // then ensure the link placeholder doesn't contain a link
-                    if getURL(content.string) == nil {
-                        // overwrite styling to avoid bold, italic, code links
-                        content.addAttributes(style.defaultAttributes)
-                        content.addAttribute(MarkdownIDAttributeName, value: Markdown.link, range: content.wholeRange)
-                        content.addAttribute(NSLinkAttributeName, value: url, range: content.wholeRange)
-                        return content
-                    }
+                    // overwrite styling to avoid bold, italic, code links
+                    content.addAttributes(style.defaultAttributes)
+                    content.addAttribute(MarkdownIDAttributeName, value: Markdown.link, range: content.wholeRange)
+                    content.addAttribute(NSLinkAttributeName, value: url, range: content.wholeRange)
+                    return content
                 }
             }
             

--- a/Tests/ASTTests.swift
+++ b/Tests/ASTTests.swift
@@ -49,21 +49,6 @@ class ASTTests: XCTestCase {
         XCTAssertNil(attrs[.link])
     }
     
-    func testThatItDoesNotRenderLinkIfPlaceholdContainsLink() {
-        // GIVEN
-        let input = "[www.test.com](www.example.com)"
-        let down = Down(markdownString: input)
-        // WHEN
-        let result = try? down.toAttributedString(using: style)
-        // THEN
-        XCTAssertNotNil(result)
-        XCTAssertEqual(input, result!.string.trimmingCharacters(in: .whitespacesAndNewlines))
-        var range = NSMakeRange(NSNotFound, 0)
-        let attrs = result!.attributes(at: 0, effectiveRange: &range)
-        XCTAssertEqual(NSMakeRange(0, (input as NSString).length), range)
-        XCTAssertNil(attrs[.link])
-    }
-    
     func testThatItDoesNotRenderInlineOnLinkPlaceholder() {
         // GIVEN
         let input = "[**click** *me* `please`](www.wire.com)"


### PR DESCRIPTION
## What's new in this PR?

When rendering a link, we are currently requiring two things:
1. the url is valid and can be opened
2. the link name is itself not a url.

The second requirement is protection against link spoofing, as it will render the markdown link as raw text. However, such protective measures should be the responsibility of the framework user. So, should remove this second requirement.