### PR TITLE
[Fix] Bold text being rendered in Times New Roman

### DIFF
--- a/Source/Style/DownStyle.swift
+++ b/Source/Style/DownStyle.swift
@@ -244,10 +244,12 @@ public extension UIFont {
     /// A copy of the font without the light weight.
     var withoutLightWeight: UIFont {
         guard fontName.contains("Light") else { return self }
-        guard let name = fontName.split(separator: "-").first else { return self }
-        let fontDesc = UIFontDescriptor(fontAttributes: [.name: name])
-        // create the font again
-        let font = UIFont(descriptor: fontDesc, size: pointSize)
+        
+        // WORKAROUND: remove font weight by re-creating the font using the system font.
+        // This will break if you use Down with a custom font. We should find a better
+	// way to solve this problem, but that probably requires architectural changes.
+        let font = UIFont.systemFont(ofSize: pointSize)
+        
         // preserve italic trait
         return isItalic ? font.italic : font
     }


### PR DESCRIPTION
### Issue

Bold text is being rendered in Times New Roman

### Cause

Since iOS 13 it's no longer allowed create fonts using the "dot syntax", doing will trigger the following message:

> CoreText note: Client requested name ".SFUI", it will get TimesNewRomanPSMT rather than the intended font. All system UI font access should be through proper APIs such as CTFontCreateUIFontForLanguage() or +[UIFont systemFontOfSize:].

We were relying on this in order to remove the `light` weight trait from a font because a font can't be light and bold at the same time.

### Solution

For now re-create the font using the standard system font in order to get rid of the `light` weight trait.

### Notes

**JIRA**: https://wearezeta.atlassian.net/browse/ZIOS-13420