### PR TITLE
[Fix] Preserve existing markdown id when adding attributes

### DIFF
--- a/Source/Extensions/NSMutableAttributedString+Helpers.swift
+++ b/Source/Extensions/NSMutableAttributedString+Helpers.swift
@@ -51,7 +51,15 @@ extension NSMutableAttributedString {
     }
     
     func addAttributes(_ attrs: DownStyle.Attributes?) {
-        guard let attrs = attrs else { return }
+        guard var attrs = attrs else { return }
+
+        if
+            let newMarkdownId = attrs[.markdown] as? Markdown,
+            let existingMarkdownId = attribute(.markdown, at: 0, effectiveRange: nil) as? Markdown
+        {
+            attrs[.markdown] = newMarkdownId.union(existingMarkdownId)
+        }
+
         addAttributes(attrs, range: wholeRange)
     }
     

--- a/Tests/NSMutableAttributedStringTests.swift
+++ b/Tests/NSMutableAttributedStringTests.swift
@@ -62,6 +62,19 @@ class NSMutableAttributedStringTests: XCTestCase {
         XCTAssertEqual(Markdown.bold, result)
         XCTAssertEqual(NSMakeRange(0, sut.length), range)
     }
+
+    func testThatItPreservesExistingMarkownIds() {
+        // // GIVEN
+        sut = NSMutableAttributedString(string: "example")
+        sut.addAttributes([.markdown: Markdown.bold])
+        // WHEN
+        sut.addAttributes([.markdown: Markdown.italic])
+        // THEN
+        var range = NSMakeRange(NSNotFound, 0)
+        let result = sut.attribute(.markdown, at: 0, effectiveRange: &range) as? Markdown
+        XCTAssertEqual([Markdown.bold, .italic], result)
+        XCTAssertEqual(NSMakeRange(0, sut.length), range)
+    }
     
     func testThatItItalicizes() {
         // GIVEN


### PR DESCRIPTION
## Issue

Querying the markdown id within a rendered attributed string only returns a single markdown id, even when there are multiple styles in that range. 

For example, the attributed string resulting from `**_bold italic_**` would only contain a single markdown id, namely `bold`.

## Cause

The markdown id always overwritten when adding new attributes.

## Solution

Combine the new and existing markdown id when setting new attributes.

