### PR TITLE
[Fix] Out of bounds exception

### DIFF
--- a/Source/Extensions/NSMutableAttributedString+Helpers.swift
+++ b/Source/Extensions/NSMutableAttributedString+Helpers.swift
@@ -51,7 +51,7 @@ extension NSMutableAttributedString {
     }
     
     func addAttributes(_ attrs: DownStyle.Attributes?) {
-        guard var attrs = attrs else { return }
+        guard length > 0, var attrs = attrs else { return }
 
         if
             let newMarkdownId = attrs[.markdown] as? Markdown,

--- a/Tests/ASTTests.swift
+++ b/Tests/ASTTests.swift
@@ -63,5 +63,15 @@ class ASTTests: XCTestCase {
         XCTAssertNotNil(attrs[.link])
         XCTAssertEqual(style.baseFont, attrs[.font] as? UIFont)
     }
+
+    func testThatItParsesEmptyQuoteAsEmptyString() {
+        // GIVEN
+        let input = ">"
+        let down = Down(markdownString: input)
+        // WHEN
+        let result = try? down.toAttributedString(using: style)
+        // THEN
+        XCTAssertEqual(result, NSMutableAttributedString())
+    }
     
 }


### PR DESCRIPTION
# What's in this PR?

**JIRA:** https://wearezeta.atlassian.net/browse/SQSERVICES-277

## Issue

An out of bounds exception occurs when parsing an empty quote: `>`.

## Cause

We try to add attributes to the content of the quote, which is a `NSMutableAttributedString` with zero length.

## Solution

Guard that the string is non empty.