### PR TITLE
[Feature] Add option to render only valid links

### DIFF
--- a/Source/AST/AST.swift
+++ b/Source/AST/AST.swift
@@ -365,23 +365,16 @@ extension Inline : Renderable {
         case .link(let children, title: _, let urlStr):
             let content = children.render(with: style)
 
-            let styleBlock: (URL) -> Void = {
-                // overwrite styling to avoid bold, italic, code links
-                content.addAttributes(style.defaultAttributes)
-                content.addAttribute(.markdown, value: Markdown.link, range: content.wholeRange)
-                content.addAttribute(.link, value: $0, range: content.wholeRange)
-            }
-
             guard style.renderOnlyValidLinks else {
                 if let url = urlStr.flatMap(Foundation.URL.init(string:)) {
-                    styleBlock(url)
+                    styleLink(content: content, url: url, style: style)
                 }
 
                 return content
             }
 
             if let url = urlStr?.detectedURL, Application.shared.canOpenURL(url) {
-                styleBlock(url)
+                styleLink(content: content, url: url, style: style)
                 return content
             } else {
                 // the link isn't valid, so we just display the input text
@@ -393,6 +386,14 @@ extension Inline : Renderable {
             return content
         }
     }
+
+    private func styleLink(content: NSMutableAttributedString, url: URL, style: DownStyle) {
+        // overwrite styling to avoid bold, italic, code links
+        content.addAttributes(style.defaultAttributes)
+        content.addAttribute(.markdown, value: Markdown.link, range: content.wholeRange)
+        content.addAttribute(.link, value: url, range: content.wholeRange)
+    }
+
 }
 
 // MARK: - STRING DESCRIPTION

--- a/Source/AST/AST.swift
+++ b/Source/AST/AST.swift
@@ -364,30 +364,35 @@ extension Inline : Renderable {
             
         case .link(let children, title: _, let urlStr):
             let content = children.render(with: style)
-            
-            
-            let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
-            
-            // validate links
-            if let urlStr = urlStr, let detector = detector {
-                
-                let getURL: (String) -> URL? = { urlStr in
-                    let match = detector.firstMatch(in: urlStr, options: [], range: NSMakeRange(0, (urlStr as NSString).length))
-                    return match?.url
-                }
-                
-                // first ensure the urlStr is valid
-                if let url = getURL(urlStr), Application.shared.canOpenURL(url) {
-                    // overwrite styling to avoid bold, italic, code links
-                    content.addAttributes(style.defaultAttributes)
-                    content.addAttribute(.markdown, value: Markdown.link, range: content.wholeRange)
-                    content.addAttribute(.link, value: url, range: content.wholeRange)
-                    return content
-                }
+
+            let styleBlock: (URL) -> Void = {
+                // overwrite styling to avoid bold, italic, code links
+                content.addAttributes(style.defaultAttributes)
+                content.addAttribute(.markdown, value: Markdown.link, range: content.wholeRange)
+                content.addAttribute(.link, value: $0, range: content.wholeRange)
             }
-            
-            // the link isn't valid, so we just display the input text
-            return NSMutableAttributedString(string: "[\(content.string)](\(urlStr ?? ""))", attributes: style.defaultAttributes)
+
+            guard style.renderOnlyValidLinks else {
+                if let url = urlStr.flatMap(Foundation.URL.init(string:)) {
+                    styleBlock(url)
+                }
+
+                return content
+            }
+
+            let getURL: (String) -> URL? = { urlStr in
+                let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+                let match = detector?.firstMatch(in: urlStr, options: [], range: NSMakeRange(0, (urlStr as NSString).length))
+                return match?.url
+            }
+
+            if let url = urlStr.flatMap(getURL), Application.shared.canOpenURL(url) {
+                styleBlock(url)
+                return content
+            } else {
+                // the link isn't valid, so we just display the input text
+                return NSMutableAttributedString(string: "[\(content.string)](\(urlStr ?? ""))", attributes: style.defaultAttributes)
+            }
             
         case .image(let children, title: _, url: _):
             let content = children.render(with: style)

--- a/Source/AST/AST.swift
+++ b/Source/AST/AST.swift
@@ -380,13 +380,7 @@ extension Inline : Renderable {
                 return content
             }
 
-            let getURL: (String) -> URL? = { urlStr in
-                let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
-                let match = detector?.firstMatch(in: urlStr, options: [], range: NSMakeRange(0, (urlStr as NSString).length))
-                return match?.url
-            }
-
-            if let url = urlStr.flatMap(getURL), Application.shared.canOpenURL(url) {
+            if let url = urlStr?.detectedURL, Application.shared.canOpenURL(url) {
                 styleBlock(url)
                 return content
             } else {
@@ -497,4 +491,16 @@ extension Inline : CustomStringConvertible {
         
         return String(repeating: "\t", count: indent) + str
     }
+}
+
+// MARK: - Helpers
+
+private extension String {
+
+    var detectedURL: URL? {
+        let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+        let match = detector?.firstMatch(in: self, options: [], range: NSMakeRange(0, (self as NSString).length))
+        return match?.url
+    }
+
 }

--- a/Source/Extensions/NSMutableAttributedString+Helpers.swift
+++ b/Source/Extensions/NSMutableAttributedString+Helpers.swift
@@ -51,7 +51,7 @@ extension NSMutableAttributedString {
     }
     
     func addAttributes(_ attrs: DownStyle.Attributes?) {
-        guard var attrs = attrs else { return }
+        guard length > 0, var attrs = attrs else { return }
 
         if
             let newMarkdownId = attrs[.markdown] as? Markdown,

--- a/Source/Style/DownStyle.swift
+++ b/Source/Style/DownStyle.swift
@@ -44,6 +44,10 @@ import UIKit
     
     public var quoteColor: UIColor? = .gray
     public var quoteParagraphStyle: NSParagraphStyle? = NSParagraphStyle.default.indentedBy(points: 24)
+
+    /// If true, then only links with valid urls will be rendered. Invalid links
+    /// will be rendered as raw markdown.
+    public var renderOnlyValidLinks = true
         
     /// The amount of space between the prefix and content of a list item
     public var listItemPrefixSpacing: CGFloat = 8

--- a/Tests/ASTTests.swift
+++ b/Tests/ASTTests.swift
@@ -63,5 +63,15 @@ class ASTTests: XCTestCase {
         XCTAssertNotNil(attrs[.link])
         XCTAssertEqual(style.baseFont, attrs[.font] as? UIFont)
     }
+
+    func testThatItParsesEmptyQuoteAsEmptyString() {
+        // GIVEN
+        let input = ">"
+        let down = Down(markdownString: input)
+        // WHEN
+        let result = try? down.toAttributedString(using: style)
+        // THEN
+        XCTAssertEqual(result, NSMutableAttributedString())
+    }
     
 }


### PR DESCRIPTION
# What's in this PR?

We only render markdown links when the URL they point to is a valid link (i.e it is well formed and can be opened). If the url isn't valid, then the link isn't rendered as a markdown link, but rather as just the raw markdown string. 

However, there are some cases where we might want to allow non standard urls to be rendered in a markdown link, such as when we wish to add a link to a system message to open a list of devices. In order to support this, I've added an option to the styler to `renderOnlyValidLinks`. If true (which is the default), then the current behaviors preserved. If false, then we will render other kinds of urls as markdown links too.